### PR TITLE
Add feature to disable popup notifications of closing tabs

### DIFF
--- a/TabMonitor.js
+++ b/TabMonitor.js
@@ -2,11 +2,13 @@
 var isDisabled=true;
 var checkerFunction;
 var noOfMinutesToClose;
+var isNotificationsEnabled;
 browser.browserAction.onClicked.addListener(onButtonClickedFunction);
 browser.browserAction.setIcon({path: browser.extension.getURL("icons/icon200disabled.png")});
 
 //Fetching Settings
 browser.storage.local.get().then(function(result){
+  isNotificationsEnabled=result.noOfMinutesToAutoClose;
   noOfMinutesToClose=result.noOfMinutesToAutoClose || "60";
   if (((result.autoStart==undefined)? false:true)? result.autoStart :false){
     onButtonClickedFunction();
@@ -33,7 +35,7 @@ function getInfoForTab(tabs) {
     }
   });
 
-  if(i>0){
+  if(i>0 && isNotificationsEnabled){
     var closingTabTask=setTimeout(function(){
              //console.log("Closing "+ i + " Tabs" );
               browser.tabs.remove(tabIdsToClose) ;

--- a/options.html
+++ b/options.html
@@ -13,6 +13,8 @@
       <input type="number" id="noOfMinutesToAutoClose" min=1 value="60" style="-moz-appearance: textfield;"><br><br>
       <label>No of Minutes to Autoclose Tab</label>
       <input type="checkbox" id="autoStart" value="1"><br><br>
+      <label>Notify when tabs are about to close</label>
+      <input type="checkbox" id="isNotificationsEnabled" value="1"><br><br>
       <button type="submit" class="button">Save</button>
   </form>
   <script src="options.js"></script>

--- a/options.js
+++ b/options.js
@@ -2,6 +2,7 @@ function saveOptions(e) {
   e.preventDefault();
   browser.storage.local.set({
     noOfMinutesToAutoClose: document.querySelector("#noOfMinutesToAutoClose").value,
+    isNotificationsEnabled: document.querySelector("#isNotificationsEnabled").value,
     autoStart: document.querySelector("#autoStart").checked
   });
 
@@ -9,6 +10,7 @@ function saveOptions(e) {
 function restoreOptions() {
   function setCurrentChoice(result) {
     document.querySelector("#noOfMinutesToAutoClose").value = result.noOfMinutesToAutoClose || "60";
+    document.querySelector("#isNotificationsEnabled").value = result.isNotificationsEnabled;
     document.querySelector("#autoStart").checked =(((result.autoStart==undefined)? false:true))? result.autoStart :false; 
   }
 


### PR DESCRIPTION
I sometimes don't need to be informed when tabs are closing. I was able to test it locally in Firefox developer after changing the manifest and submitting it to mdn for a private dev (non public) signing.